### PR TITLE
Remove task-specific instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ poetry install
 
 ## Usage
 
-The intention of this repository is to study end-to-end performance of __multi-document summarization__ (MDS) models, when the input document set must be retrieved. To do this, we provide a modified `run_summarization.py` script from HuggingFace, which makes it easy to subject different MDS models on different MDS datasets to a suite of __perturbations__. In particular, these perturbations mimic errors that a __retriever__ might make:
+The intention of this repository is to study end-to-end performance of __multi-document summarization__ (MDS) models, when the input document set must be retrieved. To do this, we provide a modified [`run_summarization.py`](scripts/run_summarization.py) script from HuggingFace, which makes it easy to subject different MDS models on different MDS datasets to a suite of __perturbations__. In particular, these perturbations mimic errors that a __retriever__ might make:
 
 - `"sorting"`: Shuffle the order of input documents to simulate different rank-ordered lists from a retriever.
 - `"duplication"`: Duplicate input documents to simulate the retrieval of duplicate (or near-duplicate) documents from a large corpus.

--- a/README.md
+++ b/README.md
@@ -8,32 +8,25 @@
 
 This repository requires Python 3.8 or later.
 
-### Installing the library and dependencies
+### Installing with pip
 
-Many dependencies are task-specific, so you will need to specify the correct task(s) via [`extras`](https://packaging.python.org/en/latest/tutorials/installing-packages/#installing-setuptools-extras). The lists of extras are:
-
-- `"summarization"`: for summarization tasks
-- `"all"`: for all tasks
-
-#### Installing with pip
-
-Install with `pip` right from GitHub, or clone the repo locally:
+Install with `pip` right from GitHub
 
 ```bash
-pip install "git+https://github.com/allenai/retrieval-exploration.git#egg=retrieval_exploration[all]"
+pip install "git+https://github.com/allenai/retrieval-exploration.git"
 ```
 
-or
+or clone the repo locally
 
 ```bash
 git clone https://github.com/allenai/retrieval-exploration.git
 cd retrieval-exploration
-pip install -e ".[all]"
+pip install -e .
 ```
 
-#### Installing with poetry
+### Installing with poetry
 
-To install using [Poetry](https://python-poetry.org/):
+To install using [Poetry](https://python-poetry.org/)
 
 ```bash
 # Install poetry for your system: https://python-poetry.org/docs/#installation
@@ -45,29 +38,27 @@ git clone https://github.com/allenai/retrieval-exploration
 cd retrieval-exploration
 
 # Install the package with poetry
-poetry install --all-extras
-
-# To install only with task-specific dependencies, use the extras argument
-poetry install --extras summarization
+poetry install
 ```
 
 ## Usage
 
-This repository provides a collection of modified `run_*.py` scripts from HuggingFace. The intention is to study the resilience of multi-document models to _document-level_ perturbations. In particular, these perturbations mimic errors that a _retriever_ might make:
+The intention of this repository is to study end-to-end performance of __multi-document summarization__ (MDS) models, when the input document set must be retrieved. To do this, we provide a modified `run_summarization.py` script from HuggingFace, which makes it easy to subject different MDS models on different MDS datasets to a suite of __perturbations__. In particular, these perturbations mimic errors that a __retriever__ might make:
 
 - `"sorting"`: Shuffle the order of input documents to simulate different rank-ordered lists from a retriever.
-- `"duplication"`: Duplicate input documents to simulate the retrieval of duplicate documents from a large corpus.
+- `"duplication"`: Duplicate input documents to simulate the retrieval of duplicate (or near-duplicate) documents from a large corpus.
 - `"addition"`: Add one or more documents to the input to mimic the retrieval of an irrelevant document. 
 - `"deletion"`: Remove one or more documents from the input to mimic the failure to retrieve a relevant document.
 - `"replacement"`: Replace one or more documents in the input with another document. This is a combination of `"addition"` and `"deletion"`.
+- `"backtranslation"`: Replace one or more documents in the input with a backtranslated copy. This mainly serves as a control.
 
-We include three different "strategies" that apply to each perturbation:
+We include three different "selection strategies" that apply to each perturbation:
 
 - `"random"`: Randomly selects documents for each perturbation.
-- `"best-case"`: Attempts to select documents in a way that is expected to minimize the harm of the perturbation. E.g. for `"addition"` in summarization, documents are selected based on similarity to the target summary.
-- `"worst-case"`: Attempts to select documents in a way that is expected to maximize the harm of the perturbation. E.g. for `"addition"` in summarization, documents are selected based on dissimilarity to the target summary.
+- `"best-case"`: Attempts to select documents in a way that is expected to _minimize_ the harm of the perturbation. E.g. for `"deletion"`, documents _least similar_ to the target summary are removed first.
+- `"worst-case"`: Attempts to select documents in a way that is expected to _maximize_ the harm of the perturbation. E.g. for `"deletion"`, documents _most similar_ to the target summary are removed first.
 
-Usage is similar to the `run_*.py` scripts from HuggingFace, but with extra arguments for the perturbation. To make things easier, we provide configs for several popular models and datasets. Here are a few examples:
+Usage is similar to the original `run_summarization*.py` script from HuggingFace, but with extra arguments for the perturbation. To make things easier, we provide configs for several popular models and datasets. Here are a few examples:
 
 Evaluate [PEGASUS](https://arxiv.org/abs/1912.08777) with the `"deletion"` perturbation and `"random"` strategy, perturbing 10% of input documents, on the [Multi-News](https://aclanthology.org/P19-1102/) dataset
 
@@ -89,11 +80,11 @@ python ./scripts/run_summarization.py "./conf/base.yml" "./conf/multixscience/pr
     --perturbed_frac 0.50
 ```
 
-Other experiments can be crafted by modifying the perturbation arguments accordingly.
+Other experiments can be crafted by modifying the perturbation arguments accordingly. New models and datasets can be added by creating your own YAML based config file. See [conf](conf) for examples.
 
 ### Notes
 
-In order to avoid duplicated computation, some perturbations will cache their results. You can get this path by calling
+In order to avoid duplicate computation, some perturbations will cache their results. You can get this path by calling
 
 ```bash
 python -c "from retrieval_exploration.common import util ; print(util.CACHE_DIR)"


### PR DESCRIPTION
Remove the task-specific instructions from the readme as we no longer have plans to look into other tasks.
