### PR TITLE
Retrieve only first 25

### DIFF
--- a/scripts/retrieval.py
+++ b/scripts/retrieval.py
@@ -156,7 +156,7 @@ def main(
     if top_k_strategy.value != TopKStrategy.oracle:
         # Following https://arxiv.org/abs/2104.06486, take the first 25 articles
         if hf_dataset_name == HFDatasets.ms2 or hf_dataset_name == HFDatasets.cochrane:
-            document_stats = pt_dataset.get_document_stats(max_included_studies=25)
+            document_stats = pt_dataset.get_document_stats(max_documents=25)
         else:
             document_stats = pt_dataset.get_document_stats()
         k = int(round(document_stats[top_k_strategy.value], 0))

--- a/scripts/retrieval.py
+++ b/scripts/retrieval.py
@@ -121,6 +121,7 @@ def main(
 
     # Use all splits if not specified
     splits = splits or list(pt_dataset._hf_dataset.keys())
+    print(f"[bold blue]:information: Will replace documents in {', '.join(splits)} splits.")
 
     # Create a new copy of the dataset and replace its source documents with retrieved documents
     hf_dataset = copy.deepcopy(pt_dataset._hf_dataset)
@@ -153,7 +154,12 @@ def main(
 
     top_k_strategy_msg = f"[bold blue]:hammer_and_wrench: Using the '{top_k_strategy.value}' TopKStrategy. "
     if top_k_strategy.value != TopKStrategy.oracle:
-        k = int(round(pt_dataset.get_document_stats()[top_k_strategy.value], 0))
+        # Following https://arxiv.org/abs/2104.06486, take the first 25 articles
+        if hf_dataset_name == HFDatasets.ms2 or hf_dataset_name == HFDatasets.cochrane:
+            document_stats = pt_dataset.get_document_stats(max_included_studies=25)
+        else:
+            document_stats = pt_dataset.get_document_stats()
+        k = int(round(document_stats[top_k_strategy.value], 0))
         print(top_k_strategy_msg + f"k will be set statically to {k} [/bold blue]")
     else:
         k = None

--- a/src/retrieval_exploration/indexing.py
+++ b/src/retrieval_exploration/indexing.py
@@ -317,9 +317,9 @@ class MSLR2022Dataset(HuggingFacePyTerrierDataset):
 
     def get_document_stats(self, **kwargs) -> Dict[str, float]:
         num_docs = []
-        max_included_studies = kwargs.get("max_included_studies")
+        max_documents = kwargs.get("max_documents")
         for split in self._hf_dataset:
             for example in self._hf_dataset[split]:
                 num_studies = len(example["pmid"])
-                num_docs.append(min(num_studies, max_included_studies) if max_included_studies else num_studies)
+                num_docs.append(min(num_studies, max_documents) if max_documents else num_studies)
         return {"max": np.max(num_docs), "mean": np.mean(num_docs), "min": np.min(num_docs)}

--- a/src/retrieval_exploration/indexing.py
+++ b/src/retrieval_exploration/indexing.py
@@ -101,7 +101,7 @@ class HuggingFacePyTerrierDataset(pt.datasets.Dataset):
         indexref = indexer.index(self.get_corpus_iter(verbose=verbose))
         return indexref
 
-    def get_document_stats(self) -> Dict[str, float]:
+    def get_document_stats(self, **kwargs) -> Dict[str, float]:
         """Returns a dictionary with corpus statistics for the given dataset. Must be implemented by child class."""
         raise NotImplementedError("Method 'get_document_stats' must be implemented by the child class.")
 
@@ -176,7 +176,7 @@ class CanonicalMDSDataset(HuggingFacePyTerrierDataset):
         labels = [1] * len(qids)
         return pd.DataFrame({"qid": qids, "docno": docnos, "label": labels})
 
-    def get_document_stats(self) -> Dict[str, float]:
+    def get_document_stats(self, **kwargs) -> Dict[str, float]:
         num_docs = []
         for split in self._hf_dataset:
             for example in self._hf_dataset[split]:
@@ -245,7 +245,7 @@ class MultiXScienceDataset(HuggingFacePyTerrierDataset):
         labels = [1] * len(qids)
         return pd.DataFrame({"qid": qids, "docno": docnos, "label": labels})
 
-    def get_document_stats(self) -> Dict[str, float]:
+    def get_document_stats(self, **kwargs) -> Dict[str, float]:
         num_docs = []
         for split in self._hf_dataset:
             for example in self._hf_dataset[split]:
@@ -315,9 +315,11 @@ class MSLR2022Dataset(HuggingFacePyTerrierDataset):
         labels = [1] * len(qids)
         return pd.DataFrame({"qid": qids, "docno": docnos, "label": labels})
 
-    def get_document_stats(self) -> Dict[str, float]:
+    def get_document_stats(self, **kwargs) -> Dict[str, float]:
         num_docs = []
+        max_included_studies = kwargs.get("max_included_studies")
         for split in self._hf_dataset:
             for example in self._hf_dataset[split]:
-                num_docs.append(len(example["pmid"]))
+                num_studies = len(example["pmid"])
+                num_docs.append(min(num_studies, max_included_studies) if max_included_studies else num_studies)
         return {"max": np.max(num_docs), "mean": np.mean(num_docs), "min": np.min(num_docs)}

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -215,6 +215,12 @@ class TestMSLR2022MS2Dataset:
         assert round(document_stats["mean"], 2) == 23.23
         assert document_stats["min"] == 1
 
+        # Check that we can cap the max number of documents
+        document_stats = ms2_pt_dataset.get_document_stats(max_documents=25)
+        assert document_stats["max"] == 25
+        assert round(document_stats["mean"], 2) == 16.57
+        assert document_stats["min"] == 1
+
 
 class TestMSLR2022CochraneDataset:
     def test_info_url(self, cochrane_pt_dataset: indexing.HuggingFacePyTerrierDataset) -> None:
@@ -281,4 +287,10 @@ class TestMSLR2022CochraneDataset:
         document_stats = cochrane_pt_dataset.get_document_stats()
         assert document_stats["max"] == 537
         assert round(document_stats["mean"], 2) == 10.91
+        assert document_stats["min"] == 1
+
+        # Check that we can cap the max number of documents
+        document_stats = cochrane_pt_dataset.get_document_stats(max_documents=25)
+        assert document_stats["max"] == 25
+        assert round(document_stats["mean"], 2) == 8.9
         assert document_stats["min"] == 1


### PR DESCRIPTION
# Overview

This PR makes two changes so that we can retrieve only the first 25 articles for Cochrane and MS2 in the retrieval experiments.

First, it `get_document_stats` now takes `kwargs`. Second, a keyword argument `max_documents` is provided to  `get_document_stats` from the `retrieval.py` script.

## Other changes

- Added tests for new kwarg `max_documents` in `get_document_stats`