### PR TITLE
Cap max docs to retrieved at 1000 by default

### DIFF
--- a/scripts/retrieval.py
+++ b/scripts/retrieval.py
@@ -12,9 +12,9 @@ from rich import print
 
 app = typer.Typer()
 
-# This controls the sizes of batches which are written to disk by HuggingFace Datasets.
-# Smaller values save memory at the cost of more compute
-_WRITER_BATCH_SIZE = 500
+# The maximum number of results to retrieve per query. Large values will increase the amount of memory consumed.
+# This is a good default and likely only needs to be changed if you wish to evaluate Recall at values > 1000.
+NUM_RESULTS_PER_QUERY = 1000
 
 # The default location to save document indices.
 _DOCUMENT_INDEX_DIR = Path(util.CACHE_DIR) / "indices"
@@ -121,7 +121,7 @@ def main(
 
     # Use all splits if not specified
     splits = splits or list(pt_dataset._hf_dataset.keys())
-    print(f"[bold blue]:information: Will replace documents in {', '.join(splits)} splits.")
+    print(f"[bold blue]:information: Will replace documents in {', '.join(splits)} splits")
 
     # Create a new copy of the dataset and replace its source documents with retrieved documents
     hf_dataset = copy.deepcopy(pt_dataset._hf_dataset)
@@ -133,7 +133,9 @@ def main(
         # See: https://pyterrier.readthedocs.io/en/latest/terrier-retrieval.html#index-like-objects
         index = pt.IndexFactory.of(indexref)
         print(f"[bold green]:white_check_mark: Loaded the index from '{index_path}' [/bold green]")
-        retrieval_pipeline = pt.BatchRetrieve(index, wmodel="BM25", metadata=["docno", "text"], verbose=True)
+        retrieval_pipeline = pt.BatchRetrieve(
+            index, wmodel="BM25", metadata=["docno", "text"], num_results=NUM_RESULTS_PER_QUERY, verbose=True
+        )
     else:
         # Import here as PyTerrier will have been initialized by this point
         from pyterrier_sentence_transformers import SentenceTransformersIndexer, SentenceTransformersRetriever
@@ -148,11 +150,14 @@ def main(
         indexer.index(pt_dataset.get_corpus_iter(verbose=True))
         print(f"[bold green]:white_check_mark: Loaded the index from '{index_path}' [/bold green]")
         retrieval_pipeline = SentenceTransformersRetriever(
-            model_name_or_path=model_name_or_path, index_path=str(index_path), verbose=False
+            model_name_or_path=model_name_or_path,
+            index_path=str(index_path),
+            num_results=NUM_RESULTS_PER_QUERY,
+            verbose=False,
         )
     print(f"[bold green]:white_check_mark: Loaded the '{retriever.value}' retrieval pipeline[/bold green]")
 
-    top_k_strategy_msg = f"[bold blue]:hammer_and_wrench: Using the '{top_k_strategy.value}' TopKStrategy. "
+    top_k_strategy_msg = f"[bold blue]:gear: Using the '{top_k_strategy.value}' TopKStrategy. "
     if top_k_strategy.value != TopKStrategy.oracle:
         # Following https://arxiv.org/abs/2104.06486, take the first 25 articles
         if hf_dataset_name == HFDatasets.ms2 or hf_dataset_name == HFDatasets.cochrane:
@@ -171,11 +176,14 @@ def main(
     for split in splits:
         # Use PyTerrier to actually perform the retrieval and then replace the source docs with the retrieved docs
         # See: https://pyterrier.readthedocs.io/en/latest/terrier-retrieval.html
+        print(
+            f"[bold]:magnifying_glass_tilted_right: Retrieving documents for each example in the '{split}' set... [/bold]"
+        )
         topics = pt_dataset.get_topics(split)
         qrels = pt_dataset.get_qrels(split)
         retrieved = retrieval_pipeline.transform(topics)
 
-        print(f"[bold blue]:test_tube: Evaluating '{retriever}' retrieval pipeline on the '{split}' set [/bold blue]")
+        print(f"[bold]:test_tube: Evaluating retrieved results on the '{split}' set [/bold]")
         print(
             pt.Experiment(
                 [retrieved],
@@ -186,6 +194,7 @@ def main(
                 save_dir=output_dir,
                 save_mode="overwrite",
                 round=4,
+                verbose=True,
             )
         )
 
@@ -197,7 +206,6 @@ def main(
             partial(pt_dataset.replace, split=split, retrieved=retrieved, k=k),
             with_indices=True,
             load_from_cache_file=not overwrite_cache,
-            writer_batch_size=_WRITER_BATCH_SIZE,
             desc=f"Re-building {split} set",
         )
         print(f"[bold blue]:repeat: Source documents in '{split}' set replaced with retrieved documents[/bold blue]")

--- a/scripts/retrieval.py
+++ b/scripts/retrieval.py
@@ -14,7 +14,8 @@ app = typer.Typer()
 
 # The maximum number of results to retrieve per query. Large values will increase the amount of memory consumed.
 # This is a good default and likely only needs to be changed if you wish to evaluate Recall at values > 1000.
-NUM_RESULTS_PER_QUERY = 1000
+# This could be made an argument to the script.
+_NUM_RESULTS_PER_QUERY = 1000
 
 # The default location to save document indices.
 _DOCUMENT_INDEX_DIR = Path(util.CACHE_DIR) / "indices"
@@ -134,7 +135,7 @@ def main(
         index = pt.IndexFactory.of(indexref)
         print(f"[bold green]:white_check_mark: Loaded the index from '{index_path}' [/bold green]")
         retrieval_pipeline = pt.BatchRetrieve(
-            index, wmodel="BM25", metadata=["docno", "text"], num_results=NUM_RESULTS_PER_QUERY, verbose=True
+            index, wmodel="BM25", metadata=["docno", "text"], num_results=_NUM_RESULTS_PER_QUERY, verbose=True
         )
     else:
         # Import here as PyTerrier will have been initialized by this point
@@ -152,7 +153,7 @@ def main(
         retrieval_pipeline = SentenceTransformersRetriever(
             model_name_or_path=model_name_or_path,
             index_path=str(index_path),
-            num_results=NUM_RESULTS_PER_QUERY,
+            num_results=_NUM_RESULTS_PER_QUERY,
             verbose=False,
         )
     print(f"[bold green]:white_check_mark: Loaded the '{retriever.value}' retrieval pipeline[/bold green]")


### PR DESCRIPTION
When running `transform`, we were consuming a huge amount of memory (>256GB!). I tracked this down to our call to `transform` in the PyTerrier library, which was creating a monster DataFrame in memory (# of queries x # of total documents). The quickest way to shrink this DataFrame and reduce the amount of memory was to limit the total number of results per query to 1000. Now, the dataframe is capped at # of queries x 1000.

This is written in as a constant, but if necc. could be changed to an argument.