### PR TITLE
Dont retrieve empty examples

### DIFF
--- a/src/retrieval_exploration/indexing.py
+++ b/src/retrieval_exploration/indexing.py
@@ -125,6 +125,13 @@ class CanonicalMDSDataset(HuggingFacePyTerrierDataset):
     def replace(
         self, example: Dict[str, Any], idx: int, *, split: str, retrieved: pd.DataFrame, k: Optional[int] = None
     ) -> Dict[str, Any]:
+
+        # The decision to skip examples with no input documents is also made in the HF run_summarization.py script.
+        # It has very little effect as this is rare (maybe 1 example in an entire dataset). However, to be
+        # consistent and to avoid errors downstream, we skip these examples as well.
+        if not example["document"].strip():
+            return example
+
         qid = f"{split}_{idx}"
         k = k or util.get_num_docs(example["document"], doc_sep_token=self._doc_sep_token)
         # We would like to get the original, unaltered text from the dataset, so we use the docno's to key in.


### PR DESCRIPTION
# Overview

Multi-News has a single example in the `test` split with no input documents. In `run_summarization.py`, this is simply skipped so that the 5622 examples become 5621. However, it was _not_ skipped during the creation of our retrieved datasets, and so it is causing all sorts of problems. This PR updates the indexing code so that empty examples are also skipped when we are replacing gold examples with retrieved documents.

## TODO

- [x] Need to delete the 4736-th example in all the retrieved datasets