### PR TITLE
Set max generation length following PRIMERA paper

### DIFF
--- a/conf/multinews/primera-zs/eval.yml
+++ b/conf/multinews/primera-zs/eval.yml
@@ -6,7 +6,8 @@ dataset_name: "multi_news"
 text_column: "document"
 summary_column: "summary"
 max_source_length: 4096
-max_target_length: 1024
+max_target_length: 256
+num_beams: 5
 
 # Seq2SeqTrainingArguments
 do_predict: true

--- a/conf/wcep/primera-zs/eval.yml
+++ b/conf/wcep/primera-zs/eval.yml
@@ -2,13 +2,13 @@
 model_name_or_path: "allenai/PRIMERA"
 
 # DataTrainingArguments
-dataset_name: "multi_x_science_sum"
-text_column: "abstract"
-summary_column: "related_work"
+dataset_name: "ccdv/WCEP-10"
+text_column: "document"
+summary_column: "summary"
 max_source_length: 4096
-max_target_length: 128
+max_target_length: 50
 num_beams: 5
 
 # Seq2SeqTrainingArguments
 do_predict: true
-per_device_eval_batch_size: 12
+per_device_eval_batch_size: 16


### PR DESCRIPTION
This PR updates all the zero-shot confs so that the max generation length follows the PRIMERA paper